### PR TITLE
meta-data "main" added

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,6 +19,7 @@
     "test",
     "tests"
   ],
+  "main": "./angular-persona.js",
   "devDependencies": {
     "angular": "~1.3.3",
     "angular-mocks": "~1.3.3"


### PR DESCRIPTION
fixes this message:

    bower angular-persona#~1.1.0      invalid-meta angular-persona is missing "main" entry in bower.json